### PR TITLE
Increase slider division count

### DIFF
--- a/osu.Game.Rulesets.Tau/Beatmaps/TauBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Tau/Beatmaps/TauBeatmapConverter.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Tau.Beatmaps
 
         public bool CanConvertToSliders = true;
         public bool CanConvertToHardBeats = true;
+        public int SliderDivisionLevel = 4;
 
         public TauBeatmapConverter(IBeatmap beatmap, Ruleset ruleset)
             : base(beatmap, ruleset)
@@ -38,7 +39,7 @@ namespace osu.Game.Rulesets.Tau.Beatmaps
                     if (!CanConvertToSliders)
                         goto default;
 
-                    if (pathData.Duration < IBeatmapDifficultyInfo.DifficultyRange(Beatmap.BeatmapInfo.BaseDifficulty.ApproachRate, 1800, 1200, 450) / 2)
+                    if (pathData.Duration < IBeatmapDifficultyInfo.DifficultyRange(Beatmap.BeatmapInfo.BaseDifficulty.ApproachRate, 1800, 1200, 450) / SliderDivisionLevel)
                         goto default;
 
                     var nodes = new List<SliderNode>();

--- a/osu.Game.Rulesets.Tau/Mods/TauModLite.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModLite.cs
@@ -4,6 +4,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Tau.Beatmaps;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Tau.Mods
 {
@@ -22,12 +23,19 @@ namespace osu.Game.Rulesets.Tau.Mods
         [SettingSource("No hard beats conversion", "Completely disables hard beats altogether.")]
         public Bindable<bool> ToggleHardBeats { get; } = new Bindable<bool>(true);
 
+        [SettingSource("Slider division level", "The minimum slider length divisor.")]
+        public BindableBeatDivisor SlidersDivisionLevel { get; } = new BindableBeatDivisor
+        {
+            Default = 2
+        };
+
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)
         {
             var converter = (TauBeatmapConverter)beatmapConverter;
 
             converter.CanConvertToSliders = !ToggleSliders.Value;
             converter.CanConvertToHardBeats = !ToggleHardBeats.Value;
+            converter.SliderDivisionLevel = SlidersDivisionLevel.Value;
         }
     }
 }


### PR DESCRIPTION
As players grow used to the current sliders, I feel like it'd be better to increate the slider count now. I've also added an option to revert to the default `2` division level.

I'm not entirely sure what we can call this option however, name suggestions are open.