### PR TITLE
Add sliders to distribution graph

### DIFF
--- a/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
+++ b/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
@@ -39,7 +39,11 @@ namespace osu.Game.Rulesets.Tau.Tests
                 {
                     events.Add(new HitEvent(i, HitResult.Great, new Beat(), new Beat(),
                         new Vector2(i - (angleRange / 2), 0)));
+                    events.Add(new HitEvent(i, HitResult.Great, new Slider(), new Slider(),
+                        new Vector2(i - (angleRange / 2), 0)));
                     events.Add(new HitEvent(i, HitResult.Great, new Beat(), new Beat(),
+                        new Vector2((angleRange / 2) - i, 0)));
+                    events.Add(new HitEvent(i, HitResult.Great, new Slider(), new Slider(),
                         new Vector2((angleRange / 2) - i, 0)));
                 }
             }
@@ -61,7 +65,11 @@ namespace osu.Game.Rulesets.Tau.Tests
                 {
                     events.Add(new HitEvent(i, HitResult.Great, new Beat(), new Beat(),
                         new Vector2(i - (angleRange / 2), 0)));
+                    events.Add(new HitEvent(i, HitResult.Great, new Slider(), new Slider(),
+                        new Vector2(i - (angleRange / 2), 0)));
                     events.Add(new HitEvent(i, HitResult.Great, new Beat(), new Beat(),
+                        new Vector2((angleRange / 2) - i, 0)));
+                    events.Add(new HitEvent(i, HitResult.Great, new Slider(), new Slider(),
                         new Vector2((angleRange / 2) - i, 0)));
                 }
             }
@@ -103,8 +111,13 @@ namespace osu.Game.Rulesets.Tau.Tests
             var hitEvents = new List<HitEvent>();
 
             for (int i = 0; i < 100; i++)
+            {
                 hitEvents.Add(new HitEvent(i - 25, HitResult.Perfect, new Beat(), new Beat(),
                     new Vector2(RNG.NextSingle(-(angleRange / 2), angleRange / 2), 0)));
+
+                hitEvents.Add(new HitEvent(i - 25, HitResult.Perfect, new Slider(), new Slider(),
+                    new Vector2(RNG.NextSingle(-(angleRange / 2), angleRange / 2), 0)));
+            }
 
             return hitEvents;
         }

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
@@ -83,7 +83,8 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             NoteSize.BindValueChanged(value => DrawableBox.Size = new Vector2(value.NewValue), true);
         }
 
-        protected override JudgementResult CreateResult(Judgement judgement) => new TauJudgementResult(HitObject, judgement);
+        protected override JudgementResult CreateResult(Judgement judgement)
+            => new TauJudgementResult(HitObject, judgement);
 
         [Resolved]
         private OsuColour colour { get; set; }

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSlider.cs
@@ -12,9 +12,11 @@ using osu.Framework.Platform;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Graphics;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Tau.Judgements;
 using osu.Game.Rulesets.Tau.UI;
 using osu.Game.Skinning;
 using osuTK.Graphics;
@@ -257,8 +259,15 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                     res.ForcefullyApplyResult(r => r.Type = result);
             }
 
-            ApplyResult(r => r.Type = result);
+            ApplyResult(r =>
+            {
+                r.Type = result;
+                ApplyCustomResult(r);
+            });
         }
+
+        protected override JudgementResult CreateResult(Judgement judgement)
+            => new TauJudgementResult(HitObject, judgement);
 
         [Resolved]
         private OsuColour colour { get; set; }

--- a/osu.Game.Rulesets.Tau/Statistics/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/Statistics/PaddleDistributionGraph.cs
@@ -32,10 +32,10 @@ namespace osu.Game.Rulesets.Tau.Statistics
         private readonly IReadOnlyList<HitEvent> beatHitEvents;
         private readonly IReadOnlyList<HitEvent> sliderHitEvents;
 
-        private double angleRange => properties.AngleRange.Value;
+        private readonly BindableBool showSliders = new(true);
+        private readonly BindableBool showBeats = new(true);
 
-        private BindableBool showSliders = new(true);
-        private BindableBool showBeats = new(true);
+        private double angleRange => properties.AngleRange.Value;
 
         public PaddleDistributionGraph(IReadOnlyList<HitEvent> hitEvents, IBeatmap beatmap)
         {

--- a/osu.Game.Rulesets.Tau/Statistics/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/Statistics/PaddleDistributionGraph.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Rulesets.Tau.Statistics
                     barsContainer.Add(new Bar
                     {
                         Origin = Anchor.TopLeft,
-                        Colour = Color4Extensions.FromHex("#00AAFF"),
+                        Colour = sliderBins.Length / 2 == i ? Color4.White : Color4Extensions.FromHex("#00AAFF"),
                         Height = Math.Max(0.075f, (float)sliderBins[i] / maxSliderCount) * 0.3f,
                         Position = Extensions.GetCircularPosition(radius - 17, i - (float)(angleRange / 2)) + new Vector2(0, radius),
                     });
@@ -175,7 +175,7 @@ namespace osu.Game.Rulesets.Tau.Statistics
                 for (int i = 0; i < beatBins.Length; i++)
                     barsContainer.Add(new Bar
                     {
-                        Colour = Color4Extensions.FromHex("#66FFCC"),
+                        Colour = sliderBins.Length / 2 == i ? Color4.White : Color4Extensions.FromHex("#66FFCC"),
                         Height = Math.Max(0.075f, (float)beatBins[i] / maxBeatCount) * 0.3f,
                         Position = Extensions.GetCircularPosition(radius - 17, i - (float)(angleRange / 2)) + new Vector2(0, radius),
                     });


### PR DESCRIPTION
Some remarks about this pr:

1. This only accounts for the slider end, I'm not entirely sure if we want to allow Ticks or Repeats to affect the slider bins as in some beatmaps, they may spam repeats.
2. I feel like the lines are too thin, but that comes at the cost of the max paddle range we currently have set at CS0.

https://user-images.githubusercontent.com/35349837/167213849-67dd0f7e-3514-4b0a-ad20-5882e3850c21.mp4

