### PR TITLE
Move away from inheriting Beat

### DIFF
--- a/osu.Game.Rulesets.Tau/Beatmaps/TauBeatmap.cs
+++ b/osu.Game.Rulesets.Tau/Beatmaps/TauBeatmap.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Tau.Beatmaps
     {
         public override IEnumerable<BeatmapStatistic> GetStatistics()
         {
-            int beats = HitObjects.Count(c => c is Beat and not SliderHeadBeat and not SliderRepeat and not SliderTick);
+            int beats = HitObjects.Count(c => c is Beat);
             int sliders = HitObjects.Count(s => s is Slider);
             int hardBeats = HitObjects.Count(hb => hb is HardBeat);
 

--- a/osu.Game.Rulesets.Tau/Difficulty/TauDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Tau/Difficulty/TauDifficultyCalculator.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Tau.Difficulty
                 MaxCombo = beatmap.GetMaxCombo(),
                 OverallDifficulty = beatmap.Difficulty.OverallDifficulty,
                 ApproachRate = preempt > 1200 ? (1800 - preempt) / 120 : (1200 - preempt) / 150 + 5,
-                NotesCount = beatmap.HitObjects.Count(h => h is Beat and not SliderHeadBeat and not SliderRepeat and not SliderTick),
+                NotesCount = beatmap.HitObjects.Count(h => h is Beat),
                 SliderCount = beatmap.HitObjects.Count(s => s is Slider),
                 HardBeatCount = beatmap.HitObjects.Count(hb => hb is HardBeat),
                 SliderFactor = aimRating > 0 ? aimRatingNoSliders / aimRating : 1
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.Tau.Difficulty
             hitWindowGreat = hitWindows.WindowFor(HitResult.Great) / clockRate;
             return new Skill[]
             {
-                new Aim(mods, typeof(Beat), typeof(Slider)),
+                new Aim(mods, typeof(Beat), typeof(SliderRepeat), typeof(Slider)),
                 new Aim(mods, typeof(Beat)),
                 new Speed(mods, hitWindowGreat)
             };

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableAngledTauHitObject.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableAngledTauHitObject.cs
@@ -45,6 +45,9 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             angleBindable.UnbindFrom(HitObject.AngleBindable);
         }
 
+        protected override JudgementResult CreateResult(Judgement judgement)
+            => new TauJudgementResult(HitObject, judgement);
+
         protected override bool CheckForValidation() => IsWithinPaddle();
 
         public bool IsWithinPaddle() => CheckValidation != null && CheckValidation((HitObject.Angle + GetCurrentOffset()).Normalize()).IsValid;

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
@@ -2,9 +2,7 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Tau.Judgements;
 using osu.Game.Rulesets.Tau.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Tau.UI;
 using osuTK;
@@ -30,11 +28,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             RelativeSizeAxes = Axes.Both;
             Size = Vector2.One;
 
-            AddInternal(DrawableBox = CreateDrawable());
-        }
-
-        protected virtual Drawable CreateDrawable()
-            => new Container
+            AddInternal(DrawableBox = new Container
             {
                 RelativePositionAxes = Axes.Both,
                 Anchor = Anchor.Centre,
@@ -43,7 +37,8 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                 AlwaysPresent = true,
                 Size = new Vector2(NoteSize.Default),
                 Child = new BeatPiece()
-            };
+            });
+        }
 
         [Resolved(canBeNull: true)]
         protected TauCachedProperties Properties { get; private set; }
@@ -65,9 +60,6 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
         {
             NoteSize.BindValueChanged(value => DrawableBox.Size = new Vector2(value.NewValue), true);
         }
-
-        protected override JudgementResult CreateResult(Judgement judgement)
-            => new TauJudgementResult(HitObject, judgement);
 
         [Resolved]
         private OsuColour colour { get; set; }

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSliderRepeat.cs
@@ -5,22 +5,43 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Tau.Objects.Drawables.Pieces;
 using osuTK;
 using System;
+using osu.Framework.Allocation;
+using osu.Game.Rulesets.Tau.UI;
 
 namespace osu.Game.Rulesets.Tau.Objects.Drawables
 {
-    public class DrawableSliderRepeat : DrawableBeat
+    public class DrawableSliderRepeat : DrawableAngledTauHitObject<SliderRepeat>
     {
+        public Drawable DrawableBox;
+
         public DrawableSlider DrawableSlider => (DrawableSlider)ParentHitObject;
 
         public override bool DisplayResult => false;
 
         public DrawableSliderRepeat()
+            : this(null)
         {
         }
 
-        public DrawableSliderRepeat(Beat hitObject)
+        public DrawableSliderRepeat(SliderRepeat hitObject)
             : base(hitObject)
         {
+            Name = "Repeat track";
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            RelativeSizeAxes = Axes.Both;
+            Size = Vector2.One;
+
+            AddInternal(DrawableBox = new Container
+            {
+                RelativePositionAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Alpha = 0,
+                AlwaysPresent = true,
+                Size = new Vector2(NoteSize.Default),
+                Child = new BeatPiece()
+            });
         }
 
         protected override void Update()
@@ -32,6 +53,15 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
         }
 
         public Drawable InnerDrawableBox;
+
+        [Resolved(canBeNull: true)]
+        protected TauCachedProperties Properties { get; private set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            NoteSize.BindValueChanged(value => DrawableBox.Size = new Vector2(value.NewValue), true);
+        }
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSliderTick.cs
@@ -1,52 +1,21 @@
 ﻿using osu.Game.Rulesets.Scoring;
-using osu.Framework.Graphics;
-
-#if SHOW_TICKS
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osuTK;
-using osuTK.Graphics;
-#endif
 
 namespace osu.Game.Rulesets.Tau.Objects.Drawables
 {
-    public class DrawableSliderTick : DrawableBeat
+    public class DrawableSliderTick : DrawableAngledTauHitObject<SliderTick>
     {
         public DrawableSlider DrawableSlider => (DrawableSlider)ParentHitObject;
 
         public override bool DisplayResult => false;
 
         public DrawableSliderTick()
+            : this(null)
         {
         }
 
-        public DrawableSliderTick(Beat hitObject)
+        public DrawableSliderTick(SliderTick hitObject)
             : base(hitObject)
         {
-        }
-
-        protected override Drawable CreateDrawable()
-        {
-#if SHOW_TICKS
-            return new Container
-            {
-                RelativePositionAxes = Axes.Both,
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Alpha = 0,
-                AlwaysPresent = true,
-                Size = new Vector2(NoteSize.Default),
-                Child = new Circle
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Colour = Color4.Red
-                }
-            };
-#else
-            return Empty();
-#endif
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Tau/Objects/SliderRepeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/SliderRepeat.cs
@@ -2,7 +2,7 @@
 
 namespace osu.Game.Rulesets.Tau.Objects
 {
-    public class SliderRepeat : Beat, IHasOffsetAngle
+    public class SliderRepeat : AngledTauHitObject, IHasOffsetAngle
     {
         public int RepeatIndex { get; set; }
 

--- a/osu.Game.Rulesets.Tau/Objects/SliderTick.cs
+++ b/osu.Game.Rulesets.Tau/Objects/SliderTick.cs
@@ -4,7 +4,7 @@ using osu.Game.Rulesets.Tau.Judgements;
 
 namespace osu.Game.Rulesets.Tau.Objects
 {
-    public class SliderTick : Beat, IHasOffsetAngle
+    public class SliderTick : AngledTauHitObject, IHasOffsetAngle
     {
         public Slider ParentSlider { get; set; }
 

--- a/osu.Game.Rulesets.Tau/UI/Effects/PlayfieldVisualizer.cs
+++ b/osu.Game.Rulesets.Tau/UI/Effects/PlayfieldVisualizer.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Tau.UI.Effects
         /// <param name="multiplier">The multiplier for the amplitude.</param>
         public void UpdateAmplitudes(float angle, float multiplier)
         {
-            var barIndex = Math.Clamp((int)angle.Remap(0, 360, 0, bars_per_visualiser), 0, bars_per_visualiser);
+            var barIndex = Math.Clamp((int)angle.Remap(0, 360, 0, bars_per_visualiser), 0, bars_per_visualiser - 1);
             amplitudes[barIndex] += multiplier;
 
             for (int i = 1; i <= bar_spread; i++)


### PR DESCRIPTION
While this caused minor issues to us as a whole, for readability's sake this was a significant issue. More notably from the usage of `c => c is Beat and not SliderHeadBeat and not SliderRepeat and not SliderTick`