### PR TITLE
Add Acronyms to Fade Out and Fade In and buff Flashlight score.

### DIFF
--- a/osu.Game.Rulesets.Tau/Mods/TauModFadeIn.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModFadeIn.cs
@@ -5,6 +5,11 @@ namespace osu.Game.Rulesets.Tau.Mods
     public class TauModFadeIn : TauModHidden
     {
         public override IconUsage? Icon => TauIcons.ModFadeIn;
+
+        public override string Acronym => "FI";
+
+        // Modification from osu!mania's description of Hidden mod.
+        public override string Description => "Beats appear out of nowhere!";
         protected override MaskingMode Mode => MaskingMode.FadeIn;
         protected override float InitialCoverage => 0.25f;
     }

--- a/osu.Game.Rulesets.Tau/Mods/TauModFadeOut.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModFadeOut.cs
@@ -5,6 +5,10 @@ namespace osu.Game.Rulesets.Tau.Mods
     public class TauModFadeOut : TauModHidden
     {
         public override IconUsage? Icon => TauIcons.ModFadeOut;
+        public override string Acronym => "FO";
+
+        // Modification from osu!mania's description of Hidden mod.
+        public override string Description => "Beats fade out before you hit them!";
         protected override MaskingMode Mode => MaskingMode.FadeOut;
         protected override float InitialCoverage => 0.4f;
     }

--- a/osu.Game.Rulesets.Tau/Mods/TauModFlashlight.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModFlashlight.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Tau.Mods
 {
     public class TauModFlashlight : TauModFlashlight<TauHitObject>
     {
-        public override double ScoreMultiplier => 1.12;
+        public override double ScoreMultiplier => 1.2;
 
         public override float DefaultFlashlightSize => 0;
 

--- a/osu.Game.Rulesets.Tau/Mods/TauModFlashlight.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModFlashlight.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Tau.Mods
 {
     public class TauModFlashlight : TauModFlashlight<TauHitObject>
     {
-        public override double ScoreMultiplier => 1.155;
+        public override double ScoreMultiplier => 1.16;
 
         public override float DefaultFlashlightSize => 0;
 

--- a/osu.Game.Rulesets.Tau/Mods/TauModFlashlight.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModFlashlight.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Tau.Mods
 {
     public class TauModFlashlight : TauModFlashlight<TauHitObject>
     {
-        public override double ScoreMultiplier => 1.2;
+        public override double ScoreMultiplier => 1.55;
 
         public override float DefaultFlashlightSize => 0;
 

--- a/osu.Game.Rulesets.Tau/Mods/TauModFlashlight.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModFlashlight.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Tau.Mods
 {
     public class TauModFlashlight : TauModFlashlight<TauHitObject>
     {
-        public override double ScoreMultiplier => 1.55;
+        public override double ScoreMultiplier => 1.155;
 
         public override float DefaultFlashlightSize => 0;
 


### PR DESCRIPTION
Fixes issue where Mod Presets are unable to store both mods, as they are both seen as HD / Hidden mods.
This change does buff the multiplier of Flashlight to 1.2x instead of the previous 1.12x seeing as both Fade Out and Fade In used to have the exact same multiplier.