### PR TITLE
Fix compatibility with 2023.207.0

### DIFF
--- a/osu.Game.Rulesets.Tau.Tests/osu.Game.Rulesets.Tau.Tests.csproj
+++ b/osu.Game.Rulesets.Tau.Tests/osu.Game.Rulesets.Tau.Tests.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.207.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\osu.Game.Rulesets.Tau\osu.Game.Rulesets.Tau.csproj" />

--- a/osu.Game.Rulesets.Tau.sln
+++ b/osu.Game.Rulesets.Tau.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29123.88
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33110.190
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Game.Rulesets.Tau", "osu.Game.Rulesets.Tau\osu.Game.Rulesets.Tau.csproj", "{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}"
 EndProject

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSlider.cs
@@ -109,6 +109,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                 case DrawableSliderHardBeat head:
                     headContainer.Child = head;
                     break;
+                
 
                 case DrawableSliderRepeat repeat:
                     repeatContainer.Add(repeat);
@@ -176,8 +177,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
         {
             base.OnFree();
             trackingCheckpoints.Clear();
-
-            slidingSample.Samples = null;
+            slidingSample?.ClearSamples();
         }
 
         protected override void LoadSamples()

--- a/osu.Game.Rulesets.Tau/osu.Game.Rulesets.Tau.csproj
+++ b/osu.Game.Rulesets.Tau/osu.Game.Rulesets.Tau.csproj
@@ -39,7 +39,7 @@
     <None Remove="Resources\Shaders\sh_DepthMask.vs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2022.1228.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2023.207.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Objects\Drawables\DrawableSlider.Calculations.cs">


### PR DESCRIPTION
I will admit, this is probably a really hacky solution and there's probably a better way of doing this, but I managed to solve a NullReferenceException that would crash osu! when playing a tau beatmap.