### PR TITLE
Move visualizer uniform block to a different set

### DIFF
--- a/osu.Game.Rulesets.Tau/Resources/Shaders/sh_VisualizerFade.fs
+++ b/osu.Game.Rulesets.Tau/Resources/Shaders/sh_VisualizerFade.fs
@@ -5,27 +5,27 @@
 layout(location = 5) in highp vec2 v_Position;
 layout(location = 2) in mediump vec2 v_TexCoord;
 
-layout(std140, set = 0, binding = 0) uniform m_visualizerParameters {
+layout(std140, set = 1, binding = 0) uniform m_visualizerParameters {
     highp vec2 centerPos;
     highp float range;
     highp float fadeRange;
 };
 
-layout(set = 0, binding = 1) uniform lowp texture2D m_texture;
-layout(set = 0, binding = 2) uniform lowp sampler m_sampler;
+layout(set = 0, binding = 0) uniform lowp texture2D m_texture;
+layout(set = 0, binding = 1) uniform lowp sampler m_sampler;
 
 layout(location = 0) out vec4 o_colour;
 
-void main(void) 
+void main(void)
 {
     vec2 diff = v_Position - centerPos;
     float dist = sqrt(diff.x * diff.x + diff.y * diff.y);
 
-    if ( dist <= range ) 
+    if ( dist <= range )
     {
         discard;
-    } 
-    else 
+    }
+    else
     {
         vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
         vec4 colour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_texture, m_sampler, -0.9), wrappedCoord);


### PR DESCRIPTION
Texture/Sampler uniforms are expected to be in their own uniform sets, separate from uniform blocks.

Related papertrail: https://discord.com/channels/188630481301012481/589331078574112768/1115308889794158643