### PR TITLE
Add an option to highlight Hard Beats

### DIFF
--- a/osu.Game.Rulesets.Tau.Tests/Objects/TestSceneHardBeat.cs
+++ b/osu.Game.Rulesets.Tau.Tests/Objects/TestSceneHardBeat.cs
@@ -1,9 +1,13 @@
 ﻿using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Tau.Configuration;
 using osu.Game.Rulesets.Tau.Objects;
 using osu.Game.Rulesets.Tau.Objects.Drawables;
 using osu.Game.Rulesets.Tau.UI;
@@ -15,14 +19,37 @@ namespace osu.Game.Rulesets.Tau.Tests.Objects
     {
         private int depthIndex;
 
-        public TestSceneHardBeat()
-        {
-            TauPlayfieldAdjustmentContainer container;
-            Add(container = new TauPlayfieldAdjustmentContainer());
+        private TauPlayfieldAdjustmentContainer container;
+        private BindableBool highlightHardNotes = new BindableBool();
 
+        [Test]
+        public void TestHardBeat()
+        {
+            AddStep("clear screen", Clear);
+            AddStep("add container", () => Add(container = new TauPlayfieldAdjustmentContainer()));
+
+            AddStep("Highlighting disabled", () => highlightHardNotes.Value = false);
             AddStep("Miss single", () => container.Child = testSingle());
             AddStep("Hit single", () => container.Child = testSingle(true));
             AddUntilStep("Wait for object despawn", () => !Children.Any(h => h is DrawableHardBeat { AllJudged: false }));
+        }
+
+        [Test]
+        public void TestHighlightedHardBeat()
+        {
+            AddStep("clear screen", Clear);
+            AddStep("add container", () => Add(container = new TauPlayfieldAdjustmentContainer()));
+
+            AddStep("Highlighting enabled", () => highlightHardNotes.Value = true);
+            AddStep("Miss single highlighted", () => container.Child = testSingle());
+            AddStep("Hit single highlighted", () => container.Child = testSingle(true));
+            AddUntilStep("Wait for object despawn", () => !Children.Any(h => h is DrawableHardBeat { AllJudged: false }));
+        }
+
+        [BackgroundDependencyLoader]
+        private void load() {
+            var config = (TauRulesetConfigManager)RulesetConfigs.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
+            config.BindWith(TauRulesetSettings.HighlightHardBeats, highlightHardNotes);
         }
 
         private Drawable testSingle(bool auto = false)

--- a/osu.Game.Rulesets.Tau.Tests/Objects/TestSceneSliderHardBeat.cs
+++ b/osu.Game.Rulesets.Tau.Tests/Objects/TestSceneSliderHardBeat.cs
@@ -1,10 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Tau.Configuration;
 using osu.Game.Rulesets.Tau.Objects;
 using osu.Game.Rulesets.Tau.Objects.Drawables;
 using osu.Game.Rulesets.Tau.UI;
@@ -17,16 +21,36 @@ namespace osu.Game.Rulesets.Tau.Tests.Objects
         private int depthIndex;
 
         private TauPlayfieldAdjustmentContainer container;
+        private BindableBool highlightHardNotes = new BindableBool();
+
+        [BackgroundDependencyLoader]
+        private void load() {
+            var config = (TauRulesetConfigManager)RulesetConfigs.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
+            config.BindWith(TauRulesetSettings.HighlightHardBeats, highlightHardNotes);
+        }
 
         [Test]
         public void TestSingleSlider()
         {
             AddStep("clear screen", Clear);
             AddStep("add container", () => Add(container = new TauPlayfieldAdjustmentContainer()));
+            AddStep("highlighting disabled", () => highlightHardNotes.Value = false);
 
             AddStep("Miss Single", () => container.Add(testSingle()));
             AddStep("Hit Single", () => container.Add(testSingle(true)));
-            AddUntilStep("Wait for object despawn", () => !Children.Any(h => h is DrawableSlider { AllJudged: false }));
+            AddUntilStep("Wait for object despawn", () => !container.Any(h => h is DrawableSlider { AllJudged: false }));
+        }
+
+        [Test]
+        public void TestHighlightedSingleSlider()
+        {
+            AddStep("clear screen", Clear);
+            AddStep("add container", () => Add(container = new TauPlayfieldAdjustmentContainer()));
+            AddStep("highlighting enabled", () => highlightHardNotes.Value = true);
+
+            AddStep("Miss single highlighted", () => container.Add(testSingle()));
+            AddStep("Hit single highlighted", () => container.Add(testSingle(true)));
+            AddUntilStep("Wait for object despawn", () => !container.Any(h => h is DrawableSlider { AllJudged: false }));
         }
 
         [Test]
@@ -35,8 +59,8 @@ namespace osu.Game.Rulesets.Tau.Tests.Objects
             AddStep("clear screen", Clear);
             AddStep("add container", () => Add(container = new TauPlayfieldAdjustmentContainer()));
 
-            AddStep("Miss Single", () => container.AddRange(testMultiple(100)));
-            AddStep("Hit Single", () => container.AddRange(testMultiple(100, true)));
+            AddStep("Miss many", () => container.AddRange(testMultiple(100)));
+            AddStep("Hit many", () => container.AddRange(testMultiple(100, true)));
         }
 
         private IEnumerable<Drawable> testMultiple(int count, bool auto = false)

--- a/osu.Game.Rulesets.Tau/Configuration/TauRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Tau/Configuration/TauRulesetConfigManager.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Rulesets.Tau.Configuration
             SetDefault(TauRulesetSettings.ShowVisualizer, true);
             SetDefault(TauRulesetSettings.ShowSliderEffects, true);
             SetDefault(TauRulesetSettings.HitLighting, false);
+            SetDefault(TauRulesetSettings.HighlightHardBeats, false);
             SetDefault(TauRulesetSettings.KiaiType, KiaiType.Turbulence);
             SetDefault(TauRulesetSettings.PlayfieldDim, 0.7f, 0, 1, 0.01f);
             SetDefault(TauRulesetSettings.NotesSize, 16f, 10, 25, 1f);
@@ -30,6 +31,7 @@ namespace osu.Game.Rulesets.Tau.Configuration
         ShowVisualizer,
         ShowSliderEffects, // There's no real reason to have a toggle for showing Kiai effects, as that's already handled under KiaiType
         HitLighting,
+        HighlightHardBeats,
         KiaiType,
         PlayfieldDim,
         NotesSize,

--- a/osu.Game.Rulesets.Tau/Localisation/SettingStrings.cs
+++ b/osu.Game.Rulesets.Tau/Localisation/SettingStrings.cs
@@ -27,6 +27,11 @@ namespace osu.Game.Rulesets.Tau.Localisation
         public static LocalisableString HitLighting => new TranslatableString(getKey(@"hit_lighting"), @"Hit Lighting");
 
         /// <summary>
+        /// "Highlight Hard Beats"
+        /// </summary>
+        public static LocalisableString HighlightHardBeats = new TranslatableString(getKey(@"highlight_hard_beats"), @"Highlight Hard Beats");
+
+        /// <summary>
         /// "Kiai Type"
         /// </summary>
         public static LocalisableString KiaiType => new TranslatableString(getKey(@"kiai_type"), @"Kiai Type");

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSlider.cs
@@ -16,6 +16,7 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Tau.Configuration;
 using osu.Game.Rulesets.Tau.Judgements;
 using osu.Game.Rulesets.Tau.UI;
 using osu.Game.Skinning;
@@ -28,6 +29,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
         public Drawable SliderHead => headContainer.Child;
 
         private readonly BindableFloat size = new(16f);
+        public BindableBool HighlightHardBeats = new(false);
 
         public float PathDistance = TauPlayfield.BASE_SIZE.X / 2;
 
@@ -141,13 +143,18 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
         private float convertNoteSizeToSliderSize(float beatSize)
             => Interpolation.ValueAt(beatSize, 2f, 7f, 10f, 25f);
 
+        private Color4 convertHighlightSettingToColor(bool highlightHardBeats)
+            => highlightHardBeats && HitObject.IsHard ? Color4.Orange : Color4.White;
+
         [BackgroundDependencyLoader]
-        private void load(IRenderer renderer, GameHost host)
+        private void load(IRenderer renderer, GameHost host, TauRulesetConfigManager config)
         {
+            config?.BindWith(TauRulesetSettings.HighlightHardBeats, HighlightHardBeats);
+
             NoteSize.BindValueChanged(value => path.PathRadius = convertNoteSizeToSliderSize(value.NewValue), true);
 
             host.DrawThread.Scheduler.AddDelayed(() => drawCache.Invalidate(), 0, true);
-            path.Texture = properties.SliderTexture ??= generateSmoothPathTexture(renderer, path.PathRadius, _ => Color4.White);
+            path.Texture = generateSmoothPathTexture(renderer, path.PathRadius, _ =>  convertHighlightSettingToColor(HighlightHardBeats.Value));
         }
 
         [Resolved]

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/Pieces/HardBeatPiece.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/Pieces/HardBeatPiece.cs
@@ -1,8 +1,10 @@
-﻿using osu.Framework.Bindables;
+﻿using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
+using osu.Game.Rulesets.Tau.Configuration;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Tau.Objects.Drawables.Pieces
@@ -10,12 +12,13 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables.Pieces
     public partial class HardBeatPiece : CircularContainer
     {
         public BindableFloat NoteSize = new(16f);
+        public BindableBool HighlightHardBeats = new(false);
 
         public HardBeatPiece()
         {
             Masking = true;
             BorderThickness = 5;
-            BorderColour = Color4.White;
+            BorderColour = HighlightHardBeats.Value ? Color4.Orange : Color4.White;
             RelativeSizeAxes = Axes.Both;
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
@@ -30,6 +33,13 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables.Pieces
             };
 
             NoteSize.BindValueChanged(value => BorderThickness = convertNoteSizeToThickness(value.NewValue));
+            HighlightHardBeats.BindValueChanged(value => BorderColour = value.NewValue ? Color4.Orange : Color4.White);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(TauRulesetConfigManager config)
+        {
+            config?.BindWith(TauRulesetSettings.HighlightHardBeats, HighlightHardBeats);
         }
 
         private float convertNoteSizeToThickness(float noteSize)

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/Pieces/StrictHardBeatPiece.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/Pieces/StrictHardBeatPiece.cs
@@ -3,6 +3,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Utils;
+using osu.Game.Rulesets.Tau.Configuration;
 using osuTK;
 using osuTK.Graphics;
 
@@ -12,10 +13,11 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables.Pieces
     {
         public BindableFloat NoteSize = new(16f);
         public BindableDouble AngleRange = new(25 * 0.75);
+        public BindableBool HighlightHardBeats = new(false);
 
         public StrictHardBeatPiece()
         {
-            Colour = Color4.White;
+            Colour = HighlightHardBeats.Value ? Color4.Orange : Color4.White;
             RelativeSizeAxes = Axes.Both;
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
@@ -28,14 +30,17 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables.Pieces
                 Progress = val.NewValue / 360;
                 Rotation = -(float)(val.NewValue / 2);
             }, true);
+            HighlightHardBeats.BindValueChanged(value => Colour = value.NewValue ? Color4.Orange : Color4.White);
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(TauRulesetConfigManager config)
         {
             // Size is set to zero here as to avoid standard fallback to original sprite's size (1,1),
             // see: https://github.com/ppy/osu-framework/blob/603e15fb2e68826e55878dfc09e1d7414b7cdf90/osu.Framework/Graphics/Sprites/Sprite.cs#L181-L182
             Size = Vector2.Zero;
+
+            config?.BindWith(TauRulesetSettings.HighlightHardBeats, HighlightHardBeats);
         }
 
         private float toNormalized(float value)

--- a/osu.Game.Rulesets.Tau/UI/TauCachedProperties.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauCachedProperties.cs
@@ -1,5 +1,4 @@
 ﻿using osu.Framework.Bindables;
-using osu.Framework.Graphics.Textures;
 using osu.Game.Beatmaps;
 using System;
 
@@ -12,7 +11,6 @@ namespace osu.Game.Rulesets.Tau.UI
     {
         public readonly BindableDouble AngleRange = new(25);
         public readonly BindableBool InverseModEnabled = new();
-        public Texture SliderTexture;
 
         /// <summary>
         /// Sets the range for the paddle.
@@ -23,10 +21,6 @@ namespace osu.Game.Rulesets.Tau.UI
             AngleRange.Value = IBeatmapDifficultyInfo.DifficultyRange(cs, 75, 25, 10);
         }
 
-        public void Dispose()
-        {
-            SliderTexture?.Dispose();
-            SliderTexture = null;
-        }
+        public void Dispose() {}
     }
 }

--- a/osu.Game.Rulesets.Tau/UI/TauSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauSettingsSubsection.cs
@@ -51,6 +51,11 @@ namespace osu.Game.Rulesets.Tau.UI
                     LabelText = SettingStrings.HitLighting,
                     Current = config.GetBindable<bool>(TauRulesetSettings.HitLighting)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = SettingStrings.HighlightHardBeats,
+                    Current = config.GetBindable<bool>(TauRulesetSettings.HighlightHardBeats)
+                },
                 kiaiType = new SettingsEnumDropdown<KiaiType>()
                 {
                     LabelText = SettingStrings.KiaiType,


### PR DESCRIPTION
## Why I opened this PR

I've been playing with tau for some time now, and it bothered me somewhat that the hard beats have the same color as regular beats. This makes it a bit harder for me to differentiate between the two and kinda makes them blur together.

When playing with the Strict mod this gets even worse. There — because the hard beats start off quite thin — it's very difficult to differentiate between hard beats and regular beats as they look almost the same.

<img src="https://github.com/taulazer/tau/assets/73030116/2022c827-b4ea-4067-97a6-92c17e5e97f1" width="40%" title="Approaching hard beat near the center of the play area">

To alleviate this I made this PR, which adds an option that changes the color of hard beats. My goal is to improve usability for players with color blindness or impaired vision, and players with some neurodevelopmental disorders.[^1]


## Changes

With the option "Highlight Hard Beats" enabled, all hard beats will now be colored orange. This includes regular hard beats, strict hard beats, and strict hard beat sliders.
I picked orange for the time being since it seems to work well enough with the accent color. It also looks different enough from white to make it easier to distinguish, but it could be improved upon.

<img src="https://github.com/taulazer/tau/assets/73030116/9c8cd7b6-7d4f-4e52-83d7-8c54d603e2a8" width="40%" title="Highlighted hard beat with a few regular beats and a slider">
<img src="https://github.com/taulazer/tau/assets/73030116/7462203a-5700-4bad-a713-c6d1c10da526" width="40%" title="Highlighted hard beats and sliders with the Strict mod">
<img src="https://github.com/taulazer/tau/assets/73030116/abdfde1d-558f-4afc-9b83-af3e0d57fff2" title="Highlight hard beats checkbox in the settings menu">

The relevant tests have been updated with additional steps to verify that these changes work as expected. Manual tests with a release build of osu! have been conducted as well.

The cached slider texture from `TauCachedProperties` has been removed to allow for changing the color of the hard beat sliders. It could be reintroduced in some fashion if it turns out these changes have a noticeable impact on performance. By far the easiest way to do this would be to revert the changes to `TauCachedProperties` and `DrawableSlider`.


## Notes

Because I'm not very familiar with C# and don't use it often the code I deliver might not be very tidy, and there will undoubtedly be inefficiencies and strange decisions all over. I did however attempt to match the style of the code I was working with.
If there is anything I could improve upon, please let me know.

[^1]: I have Autism without any visual impairments, yet I can tell that my ability to read certain patterns in both tau and standard really struggles compared to other players. Of course, I can't speak for other people with neurodevelopmental disorders, color blindness, or visual impairments.