### PR TITLE
Implement full touchscreen gameplay

### DIFF
--- a/osu.Game.Rulesets.Tau/TauInputManager.cs
+++ b/osu.Game.Rulesets.Tau/TauInputManager.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Rulesets.Tau
 		[BackgroundDependencyLoader]
         private void load()
         {
-			// same way as OsuInputTouchMapper is added to OsuInputManager
             Add(new TauTouchInputMapper(this) { RelativeSizeAxes = Axes.Both });
         }
 

--- a/osu.Game.Rulesets.Tau/TauInputManager.cs
+++ b/osu.Game.Rulesets.Tau/TauInputManager.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
-using osu.Framework.Input;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Tau.Localisation;
+using osu.Game.Rulesets.Tau.UI;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Tau
@@ -15,6 +16,7 @@ namespace osu.Game.Rulesets.Tau
 
         public bool AllowUserPresses
         {
+			get => ((TauKeyBindingContainer)KeyBindingContainer).AllowUserPresses;
             set => ((TauKeyBindingContainer)KeyBindingContainer).AllowUserPresses = value;
         }
 
@@ -32,24 +34,18 @@ namespace osu.Game.Rulesets.Tau
         {
         }
 
+		[BackgroundDependencyLoader]
+        private void load()
+        {
+			// same way as OsuInputTouchMapper is added to OsuInputManager
+            Add(new TauTouchInputMapper(this) { RelativeSizeAxes = Axes.Both });
+        }
+
         protected override bool Handle(UIEvent e)
         {
             if ((e is MouseMoveEvent || e is TouchMoveEvent) && !AllowUserCursorMovement) return false;
 
             return base.Handle(e);
-        }
-
-        protected override bool HandleMouseTouchStateChange(TouchStateChangeEvent e)
-        {
-            if (!AllowUserCursorMovement)
-            {
-                // Still allow for forwarding of the "touch" part, but replace the positional data with that of the mouse.
-                // Primarily relied upon by the "autopilot" mod.
-                var touch = new Touch(e.Touch.Source, CurrentState.Mouse.Position);
-                e = new TouchStateChangeEvent(e.State, e.Input, touch, e.IsActive, null);
-            }
-
-            return base.HandleMouseTouchStateChange(e);
         }
 
         private partial class TauKeyBindingContainer : RulesetKeyBindingContainer

--- a/osu.Game.Rulesets.Tau/UI/TauDrawableRuleset.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauDrawableRuleset.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Game.Beatmaps;
 using osu.Game.Input.Handlers;
@@ -59,6 +60,8 @@ namespace osu.Game.Rulesets.Tau.UI
         private void load()
         {
             properties.SetRange(Beatmap.Difficulty.CircleSize);
+			// same way that CatchInputTouchMapper is added to DrawableCatchRuleset
+            KeyBindingInputManager.Add(new TauHardButtonTouchInputMapper(KeyBindingInputManager) { RelativeSizeAxes = Axes.Both });
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game.Rulesets.Tau/UI/TauDrawableRuleset.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauDrawableRuleset.cs
@@ -60,7 +60,6 @@ namespace osu.Game.Rulesets.Tau.UI
         private void load()
         {
             properties.SetRange(Beatmap.Difficulty.CircleSize);
-			// same way that CatchInputTouchMapper is added to DrawableCatchRuleset
             KeyBindingInputManager.Add(new TauHardButtonTouchInputMapper(KeyBindingInputManager) { RelativeSizeAxes = Axes.Both });
         }
 

--- a/osu.Game.Rulesets.Tau/UI/TauHardButtonTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauHardButtonTouchInputMapper.cs
@@ -1,0 +1,206 @@
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osuTK;
+
+namespace osu.Game.Rulesets.Tau.UI;
+
+// basically copies CatchTouchInputMapper, without the right side buttons
+internal partial class TauHardButtonTouchInputMapper(TauInputManager inputManager) : VisibilityContainer
+{
+	public override bool PropagatePositionalInputSubTree => true;
+	public override bool PropagateNonPositionalInputSubTree => true;
+
+	private readonly Dictionary<object, TauAction> trackedActionSources = [];
+
+	private readonly KeyBindingContainer<TauAction> keyBindingContainer = inputManager.KeyBindingContainer;
+
+	private Container mainContent = null!;
+
+	private InputArea hardButton1 = null!;
+	private InputArea hardButton2 = null!;
+
+	[BackgroundDependencyLoader]
+	private void load(OsuColour colours)
+	{
+		const float width = 0.15f;
+		// Ratio between normal move area height and total input height
+		const float normal_area_height_ratio = 0.45f;
+
+		RelativeSizeAxes = Axes.Both;
+
+		Children =
+		[
+			mainContent = new Container
+			{
+				RelativeSizeAxes = Axes.Both,
+				Alpha = 0,
+				Children =
+				[
+					new Container
+					{
+						RelativeSizeAxes = Axes.Both,
+						Width = width,
+						Children =
+						[
+							hardButton1 = new InputArea(TauAction.HardButton1, trackedActionSources)
+							{
+								RelativeSizeAxes = Axes.Both,
+								Height = normal_area_height_ratio,
+								Colour = colours.Gray9,
+								Anchor = Anchor.BottomRight,
+								Origin = Anchor.BottomRight,
+							},
+							hardButton2 = new InputArea(TauAction.HardButton2, trackedActionSources)
+							{
+								RelativeSizeAxes = Axes.Both,
+								Height = 1 - normal_area_height_ratio,
+							},
+						]
+					},
+				],
+			},
+		];
+	}
+
+	protected override bool OnKeyDown(KeyDownEvent e)
+	{
+		// Hide whenever the keyboard is used.
+		Hide();
+		return false;
+	}
+
+	protected override bool OnTouchDown(TouchDownEvent e)
+	{
+		return updateAction(e.Touch.Source, getTauActionFromInput(e.ScreenSpaceTouch.Position));
+	}
+
+	protected override void OnTouchMove(TouchMoveEvent e)
+	{
+		updateAction(e.Touch.Source, getTauActionFromInput(e.ScreenSpaceTouch.Position));
+		base.OnTouchMove(e);
+	}
+
+	protected override void OnTouchUp(TouchUpEvent e)
+	{
+		updateAction(e.Touch.Source, null);
+		base.OnTouchUp(e);
+	}
+
+	private bool updateAction(object source, TauAction? newAction)
+	{
+		TauAction? actionBefore = null;
+
+		if (trackedActionSources.TryGetValue(source, out TauAction found))
+			actionBefore = found;
+
+		if (actionBefore != newAction)
+		{
+			if (newAction != null)
+				trackedActionSources[source] = newAction.Value;
+			else
+				trackedActionSources.Remove(source);
+
+			updatePressedActions();
+		}
+
+		return newAction != null;
+	}
+
+	private void updatePressedActions()
+	{
+		Show();
+
+		if (trackedActionSources.ContainsValue(TauAction.HardButton1))
+			keyBindingContainer.TriggerPressed(TauAction.HardButton1);
+		else
+			keyBindingContainer.TriggerReleased(TauAction.HardButton1);
+
+		if (trackedActionSources.ContainsValue(TauAction.HardButton2))
+			keyBindingContainer.TriggerPressed(TauAction.HardButton2);
+		else
+			keyBindingContainer.TriggerReleased(TauAction.HardButton2);
+	}
+
+	private TauAction? getTauActionFromInput(Vector2 screenSpaceInputPosition)
+	{
+		if (hardButton1.Contains(screenSpaceInputPosition))
+			return TauAction.HardButton1;
+		if (hardButton2.Contains(screenSpaceInputPosition))
+			return TauAction.HardButton2;
+		return null;
+	}
+
+	protected override void PopIn() => mainContent.FadeIn(300, Easing.OutQuint);
+
+	protected override void PopOut() => mainContent.FadeOut(300, Easing.OutQuint);
+
+	private partial class InputArea : CompositeDrawable, IKeyBindingHandler<TauAction>
+	{
+		private readonly TauAction handledAction;
+
+		private readonly Box highlightOverlay;
+
+		private readonly IEnumerable<KeyValuePair<object, TauAction>> trackedActions;
+
+		private bool isHighlighted;
+
+		public InputArea(TauAction handledAction, IEnumerable<KeyValuePair<object, TauAction>> trackedActions)
+		{
+			this.handledAction = handledAction;
+			this.trackedActions = trackedActions;
+
+			InternalChildren =
+			[
+				new Container
+				{
+					RelativeSizeAxes = Axes.Both,
+					Masking = true,
+					CornerRadius = 10,
+					Children =
+					[
+						new Box
+						{
+							RelativeSizeAxes = Axes.Both,
+							Alpha = 0.15f,
+						},
+						highlightOverlay = new Box
+						{
+							RelativeSizeAxes = Axes.Both,
+							Alpha = 0,
+							Blending = BlendingParameters.Additive,
+						}
+					]
+				}
+			];
+		}
+
+		public bool OnPressed(KeyBindingPressEvent<TauAction> _)
+		{
+			updateHighlight();
+			return false;
+		}
+
+		public void OnReleased(KeyBindingReleaseEvent<TauAction> _)
+		{
+			updateHighlight();
+		}
+
+		private void updateHighlight()
+		{
+			bool isHandling = trackedActions.Any(a => a.Value == handledAction);
+
+			if (isHandling == isHighlighted)
+				return;
+
+			isHighlighted = isHandling;
+			highlightOverlay.FadeTo(isHighlighted ? 0.1f : 0, isHighlighted ? 80 : 400, Easing.OutQuint);
+		}
+	}
+}

--- a/osu.Game.Rulesets.Tau/UI/TauHardButtonTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauHardButtonTouchInputMapper.cs
@@ -12,19 +12,24 @@ using osuTK;
 namespace osu.Game.Rulesets.Tau.UI;
 
 // basically copies CatchTouchInputMapper, without the right side buttons
-internal partial class TauHardButtonTouchInputMapper(TauInputManager inputManager) : VisibilityContainer
+public partial class TauHardButtonTouchInputMapper : VisibilityContainer
 {
 	public override bool PropagatePositionalInputSubTree => true;
 	public override bool PropagateNonPositionalInputSubTree => true;
 
 	private readonly Dictionary<object, TauAction> trackedActionSources = [];
 
-	private readonly KeyBindingContainer<TauAction> keyBindingContainer = inputManager.KeyBindingContainer;
+	private readonly KeyBindingContainer<TauAction> keyBindingContainer;
 
 	private Container mainContent = null!;
 
 	private InputArea hardButton1 = null!;
 	private InputArea hardButton2 = null!;
+
+	public TauHardButtonTouchInputMapper(TauInputManager inputManager)
+	{
+		keyBindingContainer = inputManager.KeyBindingContainer;
+	}
 
 	[BackgroundDependencyLoader]
 	private void load(OsuColour colours)
@@ -35,43 +40,37 @@ internal partial class TauHardButtonTouchInputMapper(TauInputManager inputManage
 
 		RelativeSizeAxes = Axes.Both;
 
-		Children =
-		[
-			mainContent = new Container
+		// not sure how to make this a GridContainer, leaving as is since it works
+		Child = mainContent = new Container
+		{
+			RelativeSizeAxes = Axes.Both,
+			Alpha = 0,
+			Child = new Container
 			{
 				RelativeSizeAxes = Axes.Both,
-				Alpha = 0,
+				Width = width,
 				Children =
 				[
-					new Container
+					hardButton1 = new InputArea(TauAction.HardButton1, trackedActionSources)
 					{
 						RelativeSizeAxes = Axes.Both,
-						Width = width,
-						Children =
-						[
-							hardButton1 = new InputArea(TauAction.HardButton1, trackedActionSources)
-							{
-								RelativeSizeAxes = Axes.Both,
-								Height = normal_area_height_ratio,
-								Colour = colours.Gray9,
-								Anchor = Anchor.BottomRight,
-								Origin = Anchor.BottomRight,
-							},
-							hardButton2 = new InputArea(TauAction.HardButton2, trackedActionSources)
-							{
-								RelativeSizeAxes = Axes.Both,
-								Height = 1 - normal_area_height_ratio,
-							},
-						]
+						Height = normal_area_height_ratio,
+						Colour = colours.Gray9,
+						Anchor = Anchor.BottomRight,
+						Origin = Anchor.BottomRight,
 					},
-				],
+					hardButton2 = new InputArea(TauAction.HardButton2, trackedActionSources)
+					{
+						RelativeSizeAxes = Axes.Both,
+						Height = 1 - normal_area_height_ratio,
+					},
+				]
 			},
-		];
+		};
 	}
 
 	protected override bool OnKeyDown(KeyDownEvent e)
 	{
-		// Hide whenever the keyboard is used.
 		Hide();
 		return false;
 	}
@@ -138,17 +137,13 @@ internal partial class TauHardButtonTouchInputMapper(TauInputManager inputManage
 	}
 
 	protected override void PopIn() => mainContent.FadeIn(300, Easing.OutQuint);
-
 	protected override void PopOut() => mainContent.FadeOut(300, Easing.OutQuint);
 
 	private partial class InputArea : CompositeDrawable, IKeyBindingHandler<TauAction>
 	{
 		private readonly TauAction handledAction;
-
 		private readonly Box highlightOverlay;
-
 		private readonly IEnumerable<KeyValuePair<object, TauAction>> trackedActions;
-
 		private bool isHighlighted;
 
 		public InputArea(TauAction handledAction, IEnumerable<KeyValuePair<object, TauAction>> trackedActions)
@@ -156,29 +151,26 @@ internal partial class TauHardButtonTouchInputMapper(TauInputManager inputManage
 			this.handledAction = handledAction;
 			this.trackedActions = trackedActions;
 
-			InternalChildren =
-			[
-				new Container
-				{
-					RelativeSizeAxes = Axes.Both,
-					Masking = true,
-					CornerRadius = 10,
-					Children =
-					[
-						new Box
-						{
-							RelativeSizeAxes = Axes.Both,
-							Alpha = 0.15f,
-						},
-						highlightOverlay = new Box
-						{
-							RelativeSizeAxes = Axes.Both,
-							Alpha = 0,
-							Blending = BlendingParameters.Additive,
-						}
-					]
-				}
-			];
+			InternalChild = new Container
+			{
+				RelativeSizeAxes = Axes.Both,
+				Masking = true,
+				CornerRadius = 10,
+				Children =
+				[
+					new Box
+					{
+						RelativeSizeAxes = Axes.Both,
+						Alpha = 0.15f,
+					},
+					highlightOverlay = new Box
+					{
+						RelativeSizeAxes = Axes.Both,
+						Alpha = 0,
+						Blending = BlendingParameters.Additive,
+					}
+				]
+			};
 		}
 
 		public bool OnPressed(KeyBindingPressEvent<TauAction> _)

--- a/osu.Game.Rulesets.Tau/UI/TauTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauTouchInputMapper.cs
@@ -11,7 +11,7 @@ using osuTK;
 namespace osu.Game.Rulesets.Tau.UI;
 
 // basically copies OsuTouchInputMapper, but the first finger is always the "pointer"
-internal partial class TauTouchInputMapper(TauInputManager inputManager) : Drawable
+public partial class TauTouchInputMapper(TauInputManager inputManager) : Drawable
 {
 	private readonly List<TrackedTouch> trackedTouches = [];
 	private TrackedTouch? positionTrackingTouch;
@@ -103,10 +103,16 @@ internal partial class TauTouchInputMapper(TauInputManager inputManager) : Drawa
 		}
 	}
 
-	private class TrackedTouch(TouchSource source, TauAction? action)
+	private class TrackedTouch
 	{
-		public readonly TouchSource Source = source;
-		public TauAction? Action = action;
+		public TouchSource Source { get; set; }
+		public TauAction? Action { get; set; }
+
+		public TrackedTouch(TouchSource source, TauAction? action)
+		{
+			Source = source;
+			Action = action;
+		}
 
 		/// <summary>
 		/// The total distance on screen travelled by this touch (in local pixels).

--- a/osu.Game.Rulesets.Tau/UI/TauTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauTouchInputMapper.cs
@@ -1,0 +1,116 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Input;
+using osu.Framework.Input.Events;
+using osu.Framework.Input.StateChanges;
+using osuTK;
+
+namespace osu.Game.Rulesets.Tau.UI;
+
+// basically copies OsuTouchInputMapper, but the first finger is always the "pointer"
+internal partial class TauTouchInputMapper(TauInputManager inputManager) : Drawable
+{
+	private readonly List<TrackedTouch> trackedTouches = [];
+	private TrackedTouch? positionTrackingTouch;
+
+	// Required to handle touches outside of the playfield when screen scaling is enabled.
+	public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
+
+	protected override bool OnTouchDown(TouchDownEvent e)
+	{
+		var action = trackedTouches.Any(t => t.Action == TauAction.LeftButton)
+			? TauAction.RightButton
+			: TauAction.LeftButton;
+
+		// Ignore any taps which trigger an action which is already handled. But track them for potential positional input in the future.
+		bool shouldResultInAction = inputManager.AllowUserPresses && trackedTouches.All(t => t.Action != action);
+
+		var newTouch = new TrackedTouch(e.Touch.Source, shouldResultInAction ? action : null);
+
+		updatePositionTrackingTouch(newTouch);
+
+		trackedTouches.Add(newTouch);
+
+		// Important to update position before triggering the pressed action.
+		handleTouchMovement(e);
+
+		if (shouldResultInAction)
+			inputManager.KeyBindingContainer.TriggerPressed(action);
+
+		return true;
+	}
+
+	protected override void OnTouchMove(TouchMoveEvent e)
+	{
+		base.OnTouchMove(e);
+		handleTouchMovement(e);
+	}
+
+	protected override void OnTouchUp(TouchUpEvent e)
+	{
+		var tracked = trackedTouches.Single(t => t.Source == e.Touch.Source);
+
+		if (tracked.Action is TauAction action)
+			inputManager.KeyBindingContainer.TriggerReleased(action);
+
+		if (positionTrackingTouch == tracked)
+			positionTrackingTouch = null;
+
+		trackedTouches.Remove(tracked);
+
+		base.OnTouchUp(e);
+	}
+
+	private void handleTouchMovement(TouchEvent touchEvent)
+	{
+		if (touchEvent is TouchMoveEvent moveEvent)
+		{
+			var trackedTouch = trackedTouches.Single(t => t.Source == touchEvent.Touch.Source);
+			trackedTouch.DistanceTravelled += moveEvent.Delta.Length;
+		}
+
+		// Movement should only be tracked for the positionTrackingTouch.
+		if (touchEvent.Touch.Source != positionTrackingTouch?.Source)
+			return;
+
+		if (!inputManager.AllowUserCursorMovement)
+			return;
+
+		new MousePositionAbsoluteInput { Position = touchEvent.ScreenSpaceTouch.Position }.Apply(inputManager.CurrentState, inputManager);
+	}
+
+	private void updatePositionTrackingTouch(TrackedTouch newTouch)
+	{
+		// We only want to use the new touch for position tracking if no other touch is tracking position yet.
+		// This makes the first finger the "cursor", which makes tapping far-away bursts easier by using finger 1 to jump,
+		// hitting the first note, while the others are used to alternating to hit the rest of the notes in the burst.
+		if (positionTrackingTouch == null)
+		{
+			positionTrackingTouch = newTouch;
+			return;
+		}
+
+		// In the case the new touch was not used for position tracking, we should also check the previous position tracking touch.
+		// If it still has its action pressed, that action should be released.
+		// This is done to allow tracking with the initial touch while still having both Left/Right actions available for alternating with two more touches.
+		if (positionTrackingTouch.Action is TauAction touchAction)
+		{
+			inputManager.KeyBindingContainer.TriggerReleased(touchAction);
+			positionTrackingTouch.Action = null;
+		}
+	}
+
+	private class TrackedTouch(TouchSource source, TauAction? action)
+	{
+		public readonly TouchSource Source = source;
+		public TauAction? Action = action;
+
+		/// <summary>
+		/// The total distance on screen travelled by this touch (in local pixels).
+		/// </summary>
+		public float DistanceTravelled;
+	}
+}


### PR DESCRIPTION
Just as the title says. Here's a video of my bad gameplay but with all inputs properly mapped to the Tau keybinds.
https://streamable.com/chio4f

### Touch input overview
- To hit the normal notes & sliders, tap anywhere on the screen, which simply moves the ingame cursor and initiates a Tau button press (either Left or Right). This is nearly identical to the [osu!standard touch logic](https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs): the one difference being that there is no longer a delay between when the first finger touches the screen and when it is starts to act as the "pointer" or "cursor".
- To hit Hard Beats, the idea right now is for dedicated buttons on the screen to act as the Hard Buttons. As of the creation of this PR they are on the left side of the screen and span the screen's height, just like the [osu!catch ruleset buttons](https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Catch/UI/CatchTouchInputMapper.cs).

Please leave feedback or feel free to make commits to the branch. Would love to see this make a release. FYI this branch was created from the #524 branch, hopefully this shouldn't be a problem (considering it needs to actually work).