### PR TITLE
add new mod icons

### DIFF
--- a/osu.Game.Rulesets.Tau/Mods/TauModDual.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModDual.cs
@@ -1,6 +1,8 @@
 ﻿using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Tau.Localisation;
 
@@ -13,7 +15,7 @@ namespace osu.Game.Rulesets.Tau.Mods
         public override LocalisableString Description => ModStrings.DualDescription;
         public override double ScoreMultiplier => 1;
         public override ModType Type => ModType.Fun;
-
+        public override IconUsage? Icon => OsuIcon.ModBarrelRoll;
         public override bool HasImplementation => true;
 
         [SettingSource(typeof(ModStrings), nameof(ModStrings.DualPaddleCountName))]

--- a/osu.Game.Rulesets.Tau/Mods/TauModFadeIn.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModFadeIn.cs
@@ -1,12 +1,13 @@
 ﻿using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Tau.Localisation;
 
 namespace osu.Game.Rulesets.Tau.Mods
 {
     public class TauModFadeIn : TauModHidden
     {
-        public override IconUsage? Icon => TauIcons.ModFadeIn;
+        public override IconUsage? Icon => OsuIcon.ModFadeIn;
 
         public override string Acronym => "FI";
 

--- a/osu.Game.Rulesets.Tau/Mods/TauModFadeOut.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModFadeOut.cs
@@ -1,12 +1,13 @@
 ﻿using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Tau.Localisation;
 
 namespace osu.Game.Rulesets.Tau.Mods
 {
     public class TauModFadeOut : TauModHidden
     {
-        public override IconUsage? Icon => TauIcons.ModFadeOut;
+        public override IconUsage? Icon => OsuIcon.ModHidden;
         public override string Acronym => "FO";
 
         // Modification from osu!mania's description of Hidden mod.

--- a/osu.Game.Rulesets.Tau/Mods/TauModLite.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModLite.cs
@@ -4,6 +4,8 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Input;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Tau.Beatmaps;
 using osu.Game.Rulesets.Tau.Localisation;
@@ -15,7 +17,7 @@ namespace osu.Game.Rulesets.Tau.Mods
         public override string Name => "Lite";
         public override string Acronym => "LT";
         public override double ScoreMultiplier => 1.0;
-        public override IconUsage? Icon => FontAwesome.Solid.History;
+        public override IconUsage? Icon => OsuIcon.ModClassic;
         public override LocalisableString Description => ModStrings.LiteDescription;
         public override ModType Type => ModType.Conversion;
 

--- a/osu.Game.Rulesets.Tau/Mods/TauModRoundabout.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModRoundabout.cs
@@ -9,6 +9,7 @@ using System;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Tau.Localisation;
 using System.Collections.Generic;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Tau.Mods
 {
@@ -20,7 +21,7 @@ namespace osu.Game.Rulesets.Tau.Mods
         public override double ScoreMultiplier => 1;
         public override ModType Type => ModType.Fun;
         public override bool UserPlayable => true;
-        public override IconUsage? Icon => FontAwesome.Solid.Redo;
+        public override IconUsage? Icon => OsuIcon.ModSpunOut;
         public override bool HasImplementation => true;
 
         [SettingSource(typeof(ModStrings), nameof(ModStrings.RoundaboutDirectionName))]

--- a/osu.Game.Rulesets.Tau/Mods/TauModShowoffAutoplay.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModShowoffAutoplay.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Tau.Replays;
 
@@ -10,7 +11,7 @@ namespace osu.Game.Rulesets.Tau.Mods
 {
     public class TauModShowoffAutoplay : ModAutoplay
     {
-        public override IconUsage? Icon => FontAwesome.Regular.Eye;
+        public override IconUsage? Icon => OsuIcon.ModSynesthesia;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(TauModAutopilot) }).ToArray();
         public override bool HasImplementation => false;
 

--- a/osu.Game.Rulesets.Tau/Mods/TauModStrict.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModStrict.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Tau.Beatmaps;
 using osu.Game.Rulesets.Tau.Localisation;
@@ -14,6 +16,7 @@ namespace osu.Game.Rulesets.Tau.Mods
         public override double ScoreMultiplier => 1.2;
         public override string Acronym => "ST";
         public override ModType Type => ModType.DifficultyIncrease;
+        public override IconUsage? Icon => OsuIcon.ModStrictTracking;
         public override Type[] IncompatibleMods => new[] { typeof(TauModLenience), typeof(TauModLite) };
 
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)

--- a/osu.Game.Rulesets.Tau/Mods/TauModTraceable.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModTraceable.cs
@@ -1,4 +1,6 @@
-﻿using osu.Framework.Localisation;
+﻿using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Tau.Localisation;
 using osu.Game.Rulesets.Tau.Objects;
@@ -14,6 +16,7 @@ namespace osu.Game.Rulesets.Tau.Mods
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => ModStrings.TraceableDescription;
         public override double ScoreMultiplier => 1;
+        public override IconUsage? Icon => OsuIcon.ModTraceable;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<TauHitObject> drawableRuleset)
         {


### PR DESCRIPTION
changes: 
- Fade Out: uses standard Hidden mod icon (I gave up on editing the font file, i can't do it, for some reason its always glitched)
- Fade In: uses osu!mania Fade In mod icon
- Strict: uses osu! Strict Tracking mod icon (doesn't work the same as Strict Tracking, but i think the mod icon works for now)
- Showoff Auto: uses standard Synestheisia icon (both are an eye but one actually doesn't look too big)
- Lite: uses Classic mod icon (it already used the old classic mod icon so i just replaced it with the new one)
- Roundabout: uses Spun In icon (it has a motion of spinning in one direction, so i think it fits)
- Tracable: uses osu! Tracable icon
- Dual: uses osu! Barrel Roll icon (it has 2 arrows spinning in the same direction, so while not perfect its good enough for now i'd say)

I didn't touch Impossible Sliders and Lenience mod, not sure what to use there 